### PR TITLE
Added basic save functionality

### DIFF
--- a/Assets/Scenes/Joseph Seo/DialoguePlayer.cs
+++ b/Assets/Scenes/Joseph Seo/DialoguePlayer.cs
@@ -199,5 +199,7 @@ public class DialoguePlayer : MonoBehaviour
         {
             GameManager.Instance.state = State.Main;
         }
+
+        GameManager.Instance.SaveGame();
     }
 }

--- a/Assets/Scripts/Manager/GameManager.cs
+++ b/Assets/Scripts/Manager/GameManager.cs
@@ -320,6 +320,17 @@ public class GameManager : MonoBehaviour
         ArcEvent.TriggerArcChanged();
     }
 
+    public void SaveGame()
+    {
+        SaveData saveData = new SaveData()
+        {
+            state = state,
+            arc = arc,
+            ghostNameToStoryIndex = ghostManager.ghostNameToStoryIndex
+        };
+        SaveManager.SaveGame(saveData);
+    }
+
 
     private IEnumerator LoadEndScene()
     {

--- a/Assets/Scripts/Manager/SaveLoadSystem.meta
+++ b/Assets/Scripts/Manager/SaveLoadSystem.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ca4b3378231285e41ae5c6d06703c4ac
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Manager/SaveLoadSystem/SaveManager.cs
+++ b/Assets/Scripts/Manager/SaveLoadSystem/SaveManager.cs
@@ -1,0 +1,60 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+[Serializable]
+public class SaveData
+{
+    public State state;
+    public Arc arc;
+    public Dictionary<string, int> ghostNameToStoryIndex;
+}
+
+public class SaveManager
+{
+    private static string fileName = "savegame.json";
+    private static string FullPath => Path.Combine(Application.persistentDataPath, fileName);
+
+    public static void SaveGame(SaveData saveData)
+    {
+        string json = JsonConvert.SerializeObject(saveData, Formatting.Indented);
+        try
+        {
+            File.WriteAllText(FullPath, json);
+            Debug.Log($"Saved to {FullPath}");
+        }
+        catch (Exception e)
+        {
+            Debug.LogError("Failed to save: " + e);
+        }
+    }
+
+    public static SaveData LoadGame()
+    {
+        if (!File.Exists(FullPath))
+        {
+            Debug.LogWarning("No save file found.");
+            return null;
+        }
+
+        try
+        {
+            string json = File.ReadAllText(FullPath);
+            SaveData data = JsonConvert.DeserializeObject<SaveData>(json);
+            Debug.Log("Loaded save.");
+            return data;
+        }
+        catch (Exception e)
+        {
+            Debug.LogError("Failed to load: " + e);
+            return null;
+        }
+    }
+
+    public static void DeleteSave()
+    {
+        if (File.Exists(FullPath)) File.Delete(FullPath);
+    }
+}

--- a/Assets/Scripts/Manager/SaveLoadSystem/SaveManager.cs.meta
+++ b/Assets/Scripts/Manager/SaveLoadSystem/SaveManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a97ce1c87b1021149928149e805f0f42

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -4,6 +4,7 @@
     "com.unity.collab-proxy": "2.5.2",
     "com.unity.feature.development": "1.0.2",
     "com.unity.multiplayer.center": "1.0.0",
+    "com.unity.nuget.newtonsoft-json": "3.2.1",
     "com.unity.postprocessing": "3.4.0",
     "com.unity.render-pipelines.universal": "17.0.3",
     "com.unity.shadergraph": "17.0.3",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -102,6 +102,13 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.nuget.newtonsoft-json": {
+      "version": "3.2.1",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.performance.profile-analyzer": {
       "version": "1.2.2",
       "depth": 1,


### PR DESCRIPTION
This PR adds a simple SaveManager for saving and loading data to/from a json file.
Currently, the save function is called after each dialogue. However, it's still not fully functional in terms of saving and loading the whole game. 

Remaining work:

1. Specify what needs to be saved
2. Assign the loaded data to the manager classes and make sure they are working as expected
3. Add the load game button to the title screen

An example of the save file:

`C:\Users\[username]\AppData\LocalLow\DefaultCompany\Mourning Brew\savegame.json`
```json
{
  "state": 0,
  "arc": 1,
  "ghostNameToStoryIndex": {
    "Musician Ghost": 1,
    "News Reporter Ghost": 1,
    "Office Worker Ghost": 1,
    "Reaper": 2
  }
}
```